### PR TITLE
Fix for JWplayer crash due to JWP sdk v3.20.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,10 +46,10 @@ allprojects {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.longtailvideo.jwplayer:jwplayer-core:+'
-    implementation 'com.longtailvideo.jwplayer:jwplayer-common:+'
-    implementation 'com.longtailvideo.jwplayer:jwplayer-ima:+'
-    implementation 'com.longtailvideo.jwplayer:jwplayer-chromecast:+'
+    implementation 'com.longtailvideo.jwplayer:jwplayer-core:3.20.1'
+    implementation 'com.longtailvideo.jwplayer:jwplayer-common:3.20.1'
+    implementation 'com.longtailvideo.jwplayer:jwplayer-ima:3.20.1'
+    implementation 'com.longtailvideo.jwplayer:jwplayer-chromecast:3.20.1'
     implementation 'androidx.mediarouter:mediarouter:1.1.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 }


### PR DESCRIPTION
A new version of core jwplayer sdks 3.20.2 were released on May 4, 2022, after which crash issues was experienced while trying to play video.
So downgrading it to 3.20.1